### PR TITLE
payment: make next_url a fully qualified URL

### DIFF
--- a/assets/src/products/payments/SubmitPage.tsx
+++ b/assets/src/products/payments/SubmitPage.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { Redirect } from "react-router-dom";
 import { Helmet } from "react-helmet";
 import { PageTitle, Loader, ErrorAlert } from "@pay/web";
 
@@ -30,33 +29,32 @@ const SubmitPage: React.FC<Props> = ({ path, payment }) => {
     if (!called) {
       submitPaymentMutation();
     }
-  }, [called, submitPaymentMutation]);
+    if (payment.status === ProductPaymentStatus.Submitted) {
+      window.location.href = payment.next_url;
+    }
+  }, [called, submitPaymentMutation, payment.status, payment.next_url]);
 
-  if (payment.status === ProductPaymentStatus.Submitted) {
-    return <Redirect to={payment.next_url} />;
+  if (loading) {
+    return <Loader />;
   }
 
-  return (
-    <>
-      {loading ? (
-        <Loader />
-      ) : error || !data ? (
-        <>
-          <Helmet>
-            <title>Something went wrong</title>
-          </Helmet>
-          <PageTitle title="Something went wrong" />
-          <ErrorAlert
-            title="Unable to create payment"
-            message={error && error.message}
-            showError
-          />
-        </>
-      ) : (
-        <Redirect to={data.payment.next_url} />
-      )}
-    </>
-  );
+  if (error || !data) {
+    return (
+      <>
+        <Helmet>
+          <title>Something went wrong</title>
+        </Helmet>
+        <PageTitle title="Something went wrong" />
+        <ErrorAlert
+          title="Unable to create payment"
+          message={error && error.message}
+          showError
+        />
+      </>
+    );
+  }
+
+  return null;
 };
 
 export default SubmitPage;

--- a/clients/pay-client/lib/pay_gov_au/model/payment.ex
+++ b/clients/pay-client/lib/pay_gov_au/model/payment.ex
@@ -13,6 +13,7 @@ defmodule PayGovAu.Model.Payment do
     :description,
     :email,
     :id,
+    :next_url,
     :reference,
     :return_url
   ]
@@ -22,6 +23,7 @@ defmodule PayGovAu.Model.Payment do
           :description => String.t() | nil,
           :email => String.t() | nil,
           :id => String.t() | nil,
+          :next_url => String.t() | nil,
           :reference => String.t() | nil,
           :return_url => String.t() | nil
         }

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,6 +17,8 @@ config :pay, PayWeb.Endpoint,
   render_errors: [view: PayWeb.ErrorView, accepts: ~w(html json)],
   pubsub: [name: Pay.PubSub, adapter: Phoenix.PubSub.PG2]
 
+config :pay, :checkout_endpoint, "http://localhost:3000"
+
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -15,6 +15,8 @@ config :pay, PayWeb.Endpoint,
   url: [scheme: "https", host: System.get_env("ENDPOINT_HOST"), port: 443],
   secret_key_base: secret_key_base
 
+config :pay, :checkout_endpoint, "https://#{System.get_env("ENDPOINT_HOST")}"
+
 config :bambora,
   api_username: System.get_env("BAMBORA_USERNAME"),
   api_password: System.get_env("BAMBORA_PASSWORD")

--- a/lib/pay_web/controllers/external/payment_controller.ex
+++ b/lib/pay_web/controllers/external/payment_controller.ex
@@ -20,6 +20,7 @@ defmodule PayWeb.External.PaymentController do
             description(:string, "Description of the goods being paid for")
             email(:string, "Email address to associate with the payment")
             return_url(:string, "URL to redirect user to after payment")
+            next_url(:string, "URL where your service should direct your user next")
           end
 
           example(%{

--- a/lib/pay_web/controllers/products/product_payment_controller.ex
+++ b/lib/pay_web/controllers/products/product_payment_controller.ex
@@ -103,8 +103,7 @@ defmodule PayWeb.Products.ProductPaymentController do
            Products.submit_product_payment(
              product_payment,
              resp.data.id,
-             # Allow the frontend to redirect to the pay page URL.
-             "/pay/#{resp.data.id}"
+             resp.data.next_url
            ) do
       render(conn, "show.json",
         product_payment: product_payment,

--- a/lib/pay_web/views/external/payment_view.ex
+++ b/lib/pay_web/views/external/payment_view.ex
@@ -18,9 +18,14 @@ defmodule PayWeb.External.PaymentView do
       fee: 42,
       total_amount: 42,
       net_amount: 42,
-      state: %{},
+      state: %{
+        status: payment.status,
+        # TODO: determine based off status
+        finished: false
+      },
       gateway_transaction_id: payment.gateway_transaction_id,
       return_url: payment.return_url,
+      next_url: "#{Application.get_env(:pay, :checkout_endpoint)}/pay/#{payment.external_id}",
       email: payment.email,
       telephone_number: "some telephone_number",
       description: payment.description,

--- a/priv/static/swagger.json
+++ b/priv/static/swagger.json
@@ -98,6 +98,10 @@
           "format": "uuid",
           "type": "string"
         },
+        "next_url": {
+          "description": "URL where your service should direct your user next",
+          "type": "string"
+        },
         "reference": {
           "description": "Reference to associate with the payment",
           "type": "string"


### PR DESCRIPTION
The checkout_endpoint config represents the endpoint of a future
"checkout" app which is currently named "pay". This is the app that a
user pays a payment through.

It's necessary to configure the checkout_endpoint config in dev
because the frontend is run under create-react-app under port 3000.