### PR TITLE
products: don't send bad token to pay API

### DIFF
--- a/lib/pay_web/controllers/products/pay_client.ex
+++ b/lib/pay_web/controllers/products/pay_client.ex
@@ -1,14 +1,14 @@
 defmodule PayWeb.Products.PayClient do
   # TODO: pass in auth.
   def new() do
-    token = "TODO"
-
     middleware = [
       {Tesla.Middleware.Timeout, timeout: 5_000},
       {Tesla.Middleware.BaseUrl, PayWeb.Endpoint.url()},
       {Tesla.Middleware.EncodeJson, engine: Poison},
       {Tesla.Middleware.Headers,
-       [{"authorization", "token: " <> token}, {"user-agent", "Elixir"}]}
+       [
+         {"user-agent", "Elixir"}
+       ]}
     ]
 
     Tesla.client(middleware)


### PR DESCRIPTION
Sending TODO will cause the Pay API to think that there is a valid token
to decode and authenticate. Instead we don't pass anything until we
implement it.