### PR TITLE
ui: don't allow refund for failed trasaction & fix for cardtypes settings

### DIFF
--- a/assets/src/console/__generated__/graphql.tsx
+++ b/assets/src/console/__generated__/graphql.tsx
@@ -631,13 +631,9 @@ export type UpdateGatewayAccountCardTypesMutationVariables = {
 
 export type UpdateGatewayAccountCardTypesMutation = (
   { __typename?: 'RootMutationType' }
-  & { cardType: (
+  & { gatewayAccount: (
     { __typename?: 'GatewayAccount' }
-    & Pick<GatewayAccount, 'id'>
-    & { cardTypes: Array<(
-      { __typename?: 'CardType' }
-      & Pick<CardType, 'id' | 'label' | 'type'>
-    )> }
+    & GatewayAccountFragment
   ) }
 );
 
@@ -1170,16 +1166,11 @@ export type SubmitRefundMutationResult = ApolloReactCommon.MutationResult<Submit
 export type SubmitRefundMutationOptions = ApolloReactCommon.BaseMutationOptions<SubmitRefundMutation, SubmitRefundMutationVariables>;
 export const UpdateGatewayAccountCardTypesDocument = gql`
     mutation UpdateGatewayAccountCardTypes($gatewayAccountId: ID!, $cardTypeIds: [ID!]!) {
-  cardType: updateGatewayAccountCardTypes(gatewayAccountId: $gatewayAccountId, cardTypeIds: $cardTypeIds) {
-    id
-    cardTypes {
-      id
-      label
-      type
-    }
+  gatewayAccount: updateGatewayAccountCardTypes(gatewayAccountId: $gatewayAccountId, cardTypeIds: $cardTypeIds) {
+    ...GatewayAccount
   }
 }
-    `;
+    ${GatewayAccountFragmentDoc}`;
 export type UpdateGatewayAccountCardTypesMutationFn = ApolloReactCommon.MutationFunction<UpdateGatewayAccountCardTypesMutation, UpdateGatewayAccountCardTypesMutationVariables>;
 export type UpdateGatewayAccountCardTypesComponentProps = Omit<ApolloReactComponents.MutationComponentOptions<UpdateGatewayAccountCardTypesMutation, UpdateGatewayAccountCardTypesMutationVariables>, 'mutation'>;
 

--- a/assets/src/console/gql/queries.graphql
+++ b/assets/src/console/gql/queries.graphql
@@ -143,16 +143,11 @@ mutation UpdateGatewayAccountCardTypes(
   $gatewayAccountId: ID!
   $cardTypeIds: [ID!]!
 ) {
-  cardType: updateGatewayAccountCardTypes(
+  gatewayAccount: updateGatewayAccountCardTypes(
     gatewayAccountId: $gatewayAccountId
     cardTypeIds: $cardTypeIds
   ) {
-    id
-    cardTypes {
-      id
-      label
-      type
-    }
+    ...GatewayAccount
   }
 }
 

--- a/assets/src/console/pages/gateway-accounts/CardTypesPage.tsx
+++ b/assets/src/console/pages/gateway-accounts/CardTypesPage.tsx
@@ -17,6 +17,7 @@ import {
 import {
   GatewayAccountFragment,
   useUpdateGatewayAccountCardTypesMutation,
+  UpdateGatewayAccountCardTypesDocument,
   CardTypeBrand,
   CardTypeType,
   ServiceFragment
@@ -29,7 +30,7 @@ import { CardType } from "../../../auth/__generated__/graphql";
 import { BreadBox } from "@pay/web/components/Breadcrumb";
 
 interface FormValues {
-  cardTypes: Array<string>;
+  cardTypeIds: Array<string>;
 }
 
 const decorators = [createDecorator<FormValues>()];
@@ -58,7 +59,7 @@ const getCardTypesList = (data: CardTypesQuery, type: string) => {
     .map(cardType => (
       <React.Fragment key={cardType.id}>
         <Checkbox
-          name="cardTypes"
+          name="cardTypeIds"
           label={getCardTypeBrand(cardType)}
           value={cardType.id}
         />
@@ -72,9 +73,9 @@ const CardTypesPage: React.FC<Props> = ({ service, gatewayAccount }) => {
     updateGatewayAccountCardTypes
   ] = useUpdateGatewayAccountCardTypesMutation();
   const { loading, error, data } = useCardTypesQuery({ errorPolicy: "all" });
-  const [initialCardValues, setInitialCardValues] = React.useState(
+  /*const [initialCardValues, setInitialCardValues] = React.useState(
     gatewayAccount.cardTypes.map(cardType => cardType.id)
-  );
+  );*/
 
   return (
     <>
@@ -91,16 +92,36 @@ const CardTypesPage: React.FC<Props> = ({ service, gatewayAccount }) => {
       <P>Choose which credit and debit cards you want to accept.</P>
       <Form<FormValues>
         initialValues={{
-          cardTypes: initialCardValues
+          cardTypeIds: gatewayAccount.cardTypes.map(cardType => cardType.id)
         }}
         onSubmit={async values => {
           await updateGatewayAccountCardTypes({
             variables: {
               gatewayAccountId: gatewayAccount.id,
-              cardTypeIds: values.cardTypes
+              cardTypeIds: values.cardTypeIds
+            },
+            update(cache, { data }) {
+              console.log("Data is", data);
+              console.log("Inside update- cache is", cache);
+              if (!data) return null;
+              cache.writeQuery({
+                query: UpdateGatewayAccountCardTypesDocument,
+                data: {
+                  cardType: [data.cardType]
+                }
+              });
+              /*const cardTypes = data.cardTypes.map(cardType => cardType.cardTypeIds)
+              cache.writeQuery({
+                query: UpdateGatewayAccountCardTypesDocument,
+                data: {
+                  cardTypeIds: data.concat([
+                    updateGatewayAccountCardTypes
+                  ])
+                }
+              });*/
             }
           });
-          setInitialCardValues(values.cardTypes);
+          //setInitialCardValues(values.cardTypes);
         }}
         column
         decorators={decorators}

--- a/assets/src/console/pages/gateway-accounts/CardTypesPage.tsx
+++ b/assets/src/console/pages/gateway-accounts/CardTypesPage.tsx
@@ -72,6 +72,9 @@ const CardTypesPage: React.FC<Props> = ({ service, gatewayAccount }) => {
     updateGatewayAccountCardTypes
   ] = useUpdateGatewayAccountCardTypesMutation();
   const { loading, error, data } = useCardTypesQuery({ errorPolicy: "all" });
+  const [initialCardValues, setInitialCardValues] = React.useState(
+    gatewayAccount.cardTypes.map(cardType => cardType.id)
+  );
 
   return (
     <>
@@ -88,7 +91,7 @@ const CardTypesPage: React.FC<Props> = ({ service, gatewayAccount }) => {
       <P>Choose which credit and debit cards you want to accept.</P>
       <Form<FormValues>
         initialValues={{
-          cardTypes: gatewayAccount.cardTypes.map(cardType => cardType.id)
+          cardTypes: initialCardValues
         }}
         onSubmit={async values => {
           await updateGatewayAccountCardTypes({
@@ -97,6 +100,7 @@ const CardTypesPage: React.FC<Props> = ({ service, gatewayAccount }) => {
               cardTypeIds: values.cardTypes
             }
           });
+          setInitialCardValues(values.cardTypes);
         }}
         column
         decorators={decorators}

--- a/assets/src/console/pages/gateway-accounts/CardTypesPage.tsx
+++ b/assets/src/console/pages/gateway-accounts/CardTypesPage.tsx
@@ -17,7 +17,7 @@ import {
 import {
   GatewayAccountFragment,
   useUpdateGatewayAccountCardTypesMutation,
-  UpdateGatewayAccountCardTypesDocument,
+  GetGatewayAccountDocument,
   CardTypeBrand,
   CardTypeType,
   ServiceFragment
@@ -71,11 +71,26 @@ const getCardTypesList = (data: CardTypesQuery, type: string) => {
 const CardTypesPage: React.FC<Props> = ({ service, gatewayAccount }) => {
   const [
     updateGatewayAccountCardTypes
-  ] = useUpdateGatewayAccountCardTypesMutation();
+  ] = useUpdateGatewayAccountCardTypesMutation({
+    update: (cache, mutationResult) => {
+      if (!mutationResult.data) {
+        return;
+      }
+
+      const { gatewayAccount } = mutationResult.data;
+
+      cache.writeQuery({
+        query: GetGatewayAccountDocument,
+        variables: {
+          id: gatewayAccount.externalId
+        },
+        data: {
+          gatewayAccount
+        }
+      });
+    }
+  });
   const { loading, error, data } = useCardTypesQuery({ errorPolicy: "all" });
-  /*const [initialCardValues, setInitialCardValues] = React.useState(
-    gatewayAccount.cardTypes.map(cardType => cardType.id)
-  );*/
 
   return (
     <>
@@ -99,29 +114,8 @@ const CardTypesPage: React.FC<Props> = ({ service, gatewayAccount }) => {
             variables: {
               gatewayAccountId: gatewayAccount.id,
               cardTypeIds: values.cardTypeIds
-            },
-            update(cache, { data }) {
-              console.log("Data is", data);
-              console.log("Inside update- cache is", cache);
-              if (!data) return null;
-              cache.writeQuery({
-                query: UpdateGatewayAccountCardTypesDocument,
-                data: {
-                  cardType: [data.cardType]
-                }
-              });
-              /*const cardTypes = data.cardTypes.map(cardType => cardType.cardTypeIds)
-              cache.writeQuery({
-                query: UpdateGatewayAccountCardTypesDocument,
-                data: {
-                  cardTypeIds: data.concat([
-                    updateGatewayAccountCardTypes
-                  ])
-                }
-              });*/
             }
           });
-          //setInitialCardValues(values.cardTypes);
         }}
         column
         decorators={decorators}

--- a/assets/src/console/pages/gateway-accounts/CardTypesPage.tsx
+++ b/assets/src/console/pages/gateway-accounts/CardTypesPage.tsx
@@ -72,23 +72,12 @@ const CardTypesPage: React.FC<Props> = ({ service, gatewayAccount }) => {
   const [
     updateGatewayAccountCardTypes
   ] = useUpdateGatewayAccountCardTypesMutation({
-    update: (cache, mutationResult) => {
-      if (!mutationResult.data) {
-        return;
-      }
-
-      const { gatewayAccount } = mutationResult.data;
-
-      cache.writeQuery({
+    refetchQueries: [
+      {
         query: GetGatewayAccountDocument,
-        variables: {
-          id: gatewayAccount.externalId
-        },
-        data: {
-          gatewayAccount
-        }
-      });
-    }
+        variables: { id: gatewayAccount.externalId }
+      }
+    ]
   });
   const { loading, error, data } = useCardTypesQuery({ errorPolicy: "all" });
 

--- a/assets/src/console/pages/payments/RefundPage.tsx
+++ b/assets/src/console/pages/payments/RefundPage.tsx
@@ -103,7 +103,7 @@ const RefundPage: React.FC<Props> = ({
 
       {submitRefundResult.error ? (
         <ErrorAlert
-          title="Unable to retrieve events"
+          title="Unable to submit refund"
           message={submitRefundResult.error && submitRefundResult.error.message}
           showError
         />

--- a/lib/pay/payments.ex
+++ b/lib/pay/payments.ex
@@ -312,6 +312,14 @@ defmodule Pay.Payments do
   def get_payment_by_external_id!(external_id),
     do: Repo.get_by!(query_payments(), external_id: external_id)
 
+  def get_payment_successful(%Payment{} = payment) do
+    with gateway_transaction_id when not is_nil(gateway_transaction_id) <- payment.gateway_transaction_id do
+      {:ok, payment}
+    else
+      _ -> {:error, "Cannot refund a failed payment"}
+    end
+  end
+
   defp create_payment_changeset(attrs) do
     alias Payments.Payment.Statuses
     created = Statuses.initial() |> Statuses.status()

--- a/lib/pay/payments/gateway/bambora_gateway.ex
+++ b/lib/pay/payments/gateway/bambora_gateway.ex
@@ -35,7 +35,7 @@ defimpl Pay.Payments.Gateway, for: Pay.Payments.Gateway.BamboraGateway do
             }
           }
         } = payment,
-        %{"ott" => one_time_token}
+        %{ott: one_time_token}
       ) do
     payment_response =
       Bambora.submit_single_payment(client, %{

--- a/lib/pay_web/resolvers/mutations.ex
+++ b/lib/pay_web/resolvers/mutations.ex
@@ -25,6 +25,7 @@ defmodule PayWeb.Resolvers.Mutations do
           %{context: %{current_user: current_user}}
         ) do
       with payment <- Payments.get_payment_by_external_id!(payment_id),
+           gateway_transaction_id when not is_nil(gateway_transaction_id) <- payment.gateway_transaction_id,
            gateway <- Payments.GatewayAccount.payment_provider(payment.gateway_account),
            {:ok, %{reference: refund_reference}} <-
              Payments.Gateway.refund_payment(gateway, payment, %{amount: amount}) do
@@ -34,6 +35,8 @@ defmodule PayWeb.Resolvers.Mutations do
           gateway_transaction_id: refund_reference,
           user_external_id: current_user.external_id
         })
+        else
+          _ -> {:error, "Cannot refund a failed payment"}
       end
     end
 

--- a/lib/pay_web/resolvers/mutations.ex
+++ b/lib/pay_web/resolvers/mutations.ex
@@ -25,7 +25,7 @@ defmodule PayWeb.Resolvers.Mutations do
           %{context: %{current_user: current_user}}
         ) do
       with payment <- Payments.get_payment_by_external_id!(payment_id),
-           gateway_transaction_id when not is_nil(gateway_transaction_id) <- payment.gateway_transaction_id,
+           {:ok, Payments.get_payment_successful(payment)},
            gateway <- Payments.GatewayAccount.payment_provider(payment.gateway_account),
            {:ok, %{reference: refund_reference}} <-
              Payments.Gateway.refund_payment(gateway, payment, %{amount: amount}) do
@@ -35,8 +35,6 @@ defmodule PayWeb.Resolvers.Mutations do
           gateway_transaction_id: refund_reference,
           user_external_id: current_user.external_id
         })
-        else
-          _ -> {:error, "Cannot refund a failed payment"}
       end
     end
 


### PR DESCRIPTION
1) Refund - Don't allow refund for failed payments.
2) Settings->Manage payment types page - As soon as we configure supported cards, it updated in the backend, but front end was still showing the previous values. This issue is fixed.